### PR TITLE
Fix GitHub Pages Routing, modify Question

### DIFF
--- a/client-app/package.json
+++ b/client-app/package.json
@@ -54,6 +54,7 @@
       "last 1 safari version"
     ]
   },
+  "homepage": "https://dantiberi.github.io/Fall-2021-IPRO",
   "devDependencies": {
     "@types/react-router-dom": "^5.3.0"
   }

--- a/client-app/src/components/App.tsx
+++ b/client-app/src/components/App.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import {
-    BrowserRouter as Router,
+    HashRouter as Router,
     Switch,
     Route
 } from "react-router-dom";

--- a/client-app/src/components/Question.tsx
+++ b/client-app/src/components/Question.tsx
@@ -31,11 +31,11 @@ const Question: React.FC<QuestionProperties> = (props) => {
         if (state.answer === props.questionData.answer_a || state.answer === props.questionData.answer_b) {
             setLastAnswerResult(AnswerResult.Correct);
             props.onSolve(props.questionData);
+            // Clear input field
+            setFormState({ answer: "" });
         } else {
             setLastAnswerResult(AnswerResult.Incorrect);
-            //Clear input field 
         }
-        state.answer = "";
     }
     
     // Default state for the Answer form
@@ -44,7 +44,7 @@ const Question: React.FC<QuestionProperties> = (props) => {
     }
     
     // Create a Form state using the answer submission callback and the default state above
-    const [formState, onFormChange, onFormSubmit] = useForm(
+    const [formState, onFormChange, onFormSubmit, setFormState] = useForm(
         submitAnswerCallback,
         initialState
     );

--- a/client-app/src/components/pages/CourseMonitor.tsx
+++ b/client-app/src/components/pages/CourseMonitor.tsx
@@ -11,6 +11,8 @@ import StageEndModel from "models/StageEndModel";
 
 import getAzureFunctions from "getAzureFunctions";
 
+import Fade from '@mui/material/Fade';
+
 interface CourseMonitorProps {
     instructorData: InstructorModel
 }
@@ -88,10 +90,12 @@ const CourseMonitor: React.FC<CourseMonitorProps> = props => {
     }
 
     return (
-        <div className={styles.content}>
-            <h3>Course Monitor - {props.instructorData.fname} {props.instructorData.lname}</h3>
-            {contents}
-        </div>
+        <Fade in={true} timeout={500}>
+            <div className={styles.content}>
+                <h3>Course Monitor - {props.instructorData.fname} {props.instructorData.lname}</h3>
+                {contents}
+            </div>
+        </Fade>
     );
 }
 

--- a/client-app/src/components/pages/Home.tsx
+++ b/client-app/src/components/pages/Home.tsx
@@ -74,8 +74,8 @@ const Home: React.FC = () => {
                         <SubjectSelector callback={setSubjectName}/>
                     </div>
                     <div className={homeStyles.buttonContainer}>
-                        <Button className={homeStyles.createButton} href="/instructor" variant="contained" color="primary" startIcon={<CreateIcon />}>Instructor Portal</Button>
-                        <Button className={homeStyles.joinButton} href="/student" variant="contained" color="success" startIcon={<AddIcon />}>Student Portal</Button>
+                        <Button className={homeStyles.createButton} component={Link} to="/instructor" variant="contained" color="primary" startIcon={<CreateIcon />}>Instructor Portal</Button>
+                        <Button className={homeStyles.joinButton} component={Link} to="/student" variant="contained" color="success" startIcon={<AddIcon />}>Student Portal</Button>
                     </div>
                 </div>
             </div>

--- a/client-app/src/components/pages/InstructorPortal.tsx
+++ b/client-app/src/components/pages/InstructorPortal.tsx
@@ -3,7 +3,6 @@ import React, { useState } from "react";
 import InstructorLogin from "components/pages/InstructorLogin";
 import InstructorModel from "models/InstructorModel"; 
 import CourseMonitor from "./CourseMonitor";
-import Fade from '@mui/material/Fade';
 
 const InstructorPortal: React.FC = () => {
     const [loginResult, setLoginResult] = useState<InstructorModel | undefined>(undefined);
@@ -20,9 +19,7 @@ const InstructorPortal: React.FC = () => {
         );
     } else {
         return (
-            <Fade in={true} timeout={500}>
                 <CourseMonitor instructorData={loginResult} />
-            </Fade>
         );
     }
 };

--- a/client-app/src/hooks/useForm.ts
+++ b/client-app/src/hooks/useForm.ts
@@ -1,9 +1,9 @@
-import { useState } from "react";
+import React, { useState } from "react";
 
 type FormChangeCallback = (event: React.ChangeEvent<{ name: string, value: unknown }>) => void;
 type FormSubmitCallback = (event: React.FormEvent<HTMLFormElement>) => Promise<void>;
 
-const useForm = function<StateType>(callback: (state: StateType) => Promise<void>, initialState: StateType): [StateType, FormChangeCallback, FormSubmitCallback] {
+const useForm = function<StateType>(callback: (state: StateType) => Promise<void>, initialState: StateType): [StateType, FormChangeCallback, FormSubmitCallback, React.Dispatch<React.SetStateAction<StateType>>] {
     const [formState, setFormState] = useState(initialState);
 
     // onChange
@@ -21,7 +21,8 @@ const useForm = function<StateType>(callback: (state: StateType) => Promise<void
     return [
         formState,
         onChange,
-        onSubmit
+        onSubmit,
+        setFormState
     ];
 }
 


### PR DESCRIPTION
Fixes #108 

- Add `"homepage"` field to `package.json` to fix static file locations on GitHub Pages
- Use `HashRouter` instead of `BrowserRouter` in `App.tsx` to allow for frontend routing on GitHub Pages
- Change `useForm` hook to return `setFormState` as well to allow for explicit form state modification
- Change `Question` to clear the `answer` field of its form state upon submitting a correct answer
- Fix placement of `Fade` component around `CourseMonitor`
- Fix homepage `Button` components leading to the instructor portal / student portal