### PR TITLE
Add Quadratic Roots question generator

### DIFF
--- a/Documentation/JebraDBSetup.sql
+++ b/Documentation/JebraDBSetup.sql
@@ -51,6 +51,7 @@ INSERT INTO [dbo].subject VALUES ('Simplify Exponents');
 INSERT INTO [dbo].subject VALUES ('Simplify Exponents 2');
 INSERT INTO [dbo].subject VALUES ('Simplify Square Roots');
 INSERT INTO [dbo].subject VALUES ('Factorials');
+INSERT INTO [dbo].subject VALUES ('Quadratic Roots');
 
 CREATE TABLE [dbo].stage (
 	id					INT				NOT NULL	IDENTITY,

--- a/JebraAzureFunctions/JebraAzureFunctions/GenerateTestingQuestion.cs
+++ b/JebraAzureFunctions/JebraAzureFunctions/GenerateTestingQuestion.cs
@@ -68,6 +68,9 @@ namespace JebraAzureFunctions
                 case "System Of Equations":
                     status = Tools.InsertQuestionsAsync(Tools.GenerateUniqueQuestions(Tools.SystemOfEquations, amount, subjectId)).GetAwaiter().GetResult();
                     break;
+                case "Quadratic Roots":
+                    status = Tools.InsertQuestionsAsync(Tools.GenerateUniqueQuestions(Tools.QuadraticRoots, amount, subjectId)).GetAwaiter().GetResult();
+                    break;
                 default:
                     status = false;
                     break;

--- a/JebraAzureFunctions/JebraAzureFunctions/JebraAzureFunctions.xml
+++ b/JebraAzureFunctions/JebraAzureFunctions/JebraAzureFunctions.xml
@@ -137,5 +137,12 @@
             </summary>
             <returns></returns>
         </member>
+        <member name="M:JebraAzureFunctions.Tools.QuadraticRoots">
+            <summary>
+            Generates a monic quadratic polynomial with integer roots between -10 and 10
+            ex: x^2-5x+4 => roots are 1, 4
+            </summary>
+            <returns></returns>
+        </member>
     </members>
 </doc>

--- a/JebraAzureFunctions/JebraAzureFunctions/tools.cs
+++ b/JebraAzureFunctions/JebraAzureFunctions/tools.cs
@@ -513,6 +513,55 @@ namespace JebraAzureFunctions
             return questionModel;
         }
 
+        public static QuestionModel QuadraticRoots()
+        {
+            Random r = new Random();
+
+            // Construct equation "y = x^2 + bx + c"
+            int root1 = r.Next(-10, 10);
+            int root2 = r.Next(-10, 10);
+            int b = -root1 - root2; // coefficient of x term
+            int c = root1 * root2; // constant
+
+            string xTerm;
+            if (b > 0)
+            {
+                xTerm = $"+{b}x";
+            }
+            else if (b == 0)
+            {
+                xTerm = "";
+            }
+            else // b < 0
+            {
+                xTerm = $"{b}x";
+            }
+
+            string constant;
+            if (c > 0)
+            {
+                constant = $"+{c}";
+            }
+            else if (c == 0)
+            {
+                constant = "";
+            }
+            else // c < 0
+            {
+                constant = c.ToString();
+            }
+
+            string equation = $"x^2{xTerm}{constant}";
+
+            QuestionModel questionModel = new QuestionModel();
+            questionModel.question = equation;
+            questionModel.answer_a = root1.ToString();
+            questionModel.answer_b = root2.ToString();
+            questionModel.subject_id = GetSubjectIdFromString("Quadratic Roots");
+
+            return questionModel;
+        }
+
         //answer type is string, wont work currently
         /*
         //ex: (x + 3)*(x + 4) = x^2 + 7x + 12

--- a/JebraAzureFunctions/JebraAzureFunctions/tools.cs
+++ b/JebraAzureFunctions/JebraAzureFunctions/tools.cs
@@ -523,8 +523,8 @@ namespace JebraAzureFunctions
             Random r = new Random();
 
             // Construct expression "x^2 + bx + c"
-            int root1 = r.Next(-10, 10);
-            int root2 = r.Next(-10, 10);
+            int root1 = r.Next(-10, 11);
+            int root2 = r.Next(root1, 11);
             int b = -root1 - root2; // coefficient of x term
             int c = root1 * root2; // constant
 

--- a/JebraAzureFunctions/JebraAzureFunctions/tools.cs
+++ b/JebraAzureFunctions/JebraAzureFunctions/tools.cs
@@ -513,6 +513,11 @@ namespace JebraAzureFunctions
             return questionModel;
         }
 
+        /// <summary>
+        /// Generates a monic quadratic polynomial with integer roots between -10 and 10
+        /// ex: x^2-5x+4 => roots are 1, 4
+        /// </summary>
+        /// <returns></returns>
         public static QuestionModel QuadraticRoots()
         {
             Random r = new Random();

--- a/JebraAzureFunctions/JebraAzureFunctions/tools.cs
+++ b/JebraAzureFunctions/JebraAzureFunctions/tools.cs
@@ -522,7 +522,7 @@ namespace JebraAzureFunctions
         {
             Random r = new Random();
 
-            // Construct equation "y = x^2 + bx + c"
+            // Construct expression "x^2 + bx + c"
             int root1 = r.Next(-10, 10);
             int root2 = r.Next(-10, 10);
             int b = -root1 - root2; // coefficient of x term
@@ -556,10 +556,10 @@ namespace JebraAzureFunctions
                 constant = c.ToString();
             }
 
-            string equation = $"x^2{xTerm}{constant}";
+            string expression = $"x^2{xTerm}{constant}";
 
             QuestionModel questionModel = new QuestionModel();
-            questionModel.question = equation;
+            questionModel.question = expression;
             questionModel.answer_a = root1.ToString();
             questionModel.answer_b = root2.ToString();
             questionModel.subject_id = GetSubjectIdFromString("Quadratic Roots");

--- a/client-app/package.json
+++ b/client-app/package.json
@@ -34,7 +34,7 @@
   "scripts": {
     "predeploy": "npm run build",
     "deploy": "gh-pages -d build",
-    "start": "react-scripts --openssl-legacy-provider start",
+    "start": "react-scripts start --openssl-legacy-provider",
     "build": "react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject"


### PR DESCRIPTION
- Generates a quadratic expression of the form `x^2 + bx + c`
- This expression has integer roots between `-10` and `10` inclusive, generated in ascending order
- The answers to the question are both of the roots
- On the frontend, the expression is meant to be plotted, not shown explicitly to the user
- The user analyzes the graph to determine what the roots are
  - Demonstrates understanding of what the 'roots' of a polynomial represent graphically
- Fixes `npm start` script in `package.json` to correctly specify the flag

Closes #137 