### PR TITLE
Fix "npm run build"

### DIFF
--- a/client-app/package.json
+++ b/client-app/package.json
@@ -35,7 +35,7 @@
     "predeploy": "npm run build",
     "deploy": "gh-pages -d build",
     "start": "react-scripts --openssl-legacy-provider start",
-    "build": "react-scripts build",
+    "build": "react-scripts --openssl-legacy-provider build",
     "test": "react-scripts test",
     "eject": "react-scripts eject"
   },


### PR DESCRIPTION
`npm run deploy` depends on `npm run build`, and the build script requires the `--openssl-legacy-provider` flag to work with Node 17+. 